### PR TITLE
Correct typo in package name and add semi-colon to match other commands

### DIFF
--- a/mathematica-install.md
+++ b/mathematica-install.md
@@ -53,7 +53,7 @@ PacletInstall["PostNewtonianSelfForce"];
 PacletInstall["ReggeWheeler"];
 PacletInstall["SpinWeightedSpheroidalHarmonics"];
 PacletInstall["Teukolsky"];
-PacletInstall["PerturbationEquaations"]
+PacletInstall["PerturbationEquations"];
 ```
 
 ## Updating to latest version of a package


### PR DESCRIPTION
Correct a typo in the name of the `PerturbationEquations` package